### PR TITLE
remove unnecessary try except & explict set client-encoding

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -16,14 +16,8 @@ admin_api = Blueprint('bangumi', __name__)
 @auth_user(User.LEVEL_ADMIN)
 def collection():
     if request.method == 'POST':
-        try:
-            content = request.get_data(True, as_text=True)
-            return admin_service.add_bangumi(content)
-        except Exception as exception:
-            raise exception
-            # resp = make_response(jsonify({'msg': 'error'}), 500)
-            # resp.headers['Content-Type'] = 'application/json'
-            # return resp
+          content = request.get_data(True, as_text=True)
+          return admin_service.add_bangumi(content)
     else:
         page = int(request.args.get('page', 1))
         count = int(request.args.get('count', 10))

--- a/service/admin.py
+++ b/service/admin.py
@@ -161,8 +161,6 @@ class AdminService:
             self.__save_bangumi_cover(bangumi)
 
             return json_resp({'data': {'id': bangumi_id}})
-        except Exception as exception:
-            raise exception
         finally:
             SessionManager.Session.remove()
 

--- a/utils/SessionManager.py
+++ b/utils/SessionManager.py
@@ -13,7 +13,7 @@ class SessionManager:
     # dsn = ' '.join('%s=%s' % (k,v) for k,v in dbConfig.items())
 
     __engine_url = URL('postgresql', **__dbConfig)
-    engine = create_engine(__engine_url)
+    engine = create_engine(__engine_url, client_encoding='utf8')
     __session_factory = sessionmaker(bind=engine)
 
     Session = scoped_session(__session_factory)


### PR DESCRIPTION
re-raise exception does not gain much in flask framework.
What's worse, exception's stack trace is swallowed by unnecessary try except.

Explicit setting client encoding removes the dependence on postgresql's configuration.