### PR TITLE
hotfix for previous PR

### DIFF
--- a/alembic/versions/3ffc63f8e34f_add_cover_color_an_thumbnail_color_to_.py
+++ b/alembic/versions/3ffc63f8e34f_add_cover_color_an_thumbnail_color_to_.py
@@ -45,9 +45,12 @@ def upgrade():
         if not os.path.exists(bangumi_path):
             print 'cover not found for {0}'.format(bangumi_id)
             continue
-        cover_color = get_dominant_color(cover_path)
-        connection.execute(sa.text(
-            "UPDATE bangumi SET cover_color = '{0}' WHERE id = '{1}'".format(cover_color, bangumi_id)))
+        try:
+            cover_color = get_dominant_color(cover_path, quality=5)
+            connection.execute(sa.text(
+                "UPDATE bangumi SET cover_color = '{0}' WHERE id = '{1}'".format(cover_color, bangumi_id)))
+        except Exception as error:
+            print error
 
         # query episodes
         episode_result = connection.execute(sa.text(
@@ -59,9 +62,12 @@ def upgrade():
             if not os.path.exists(thumbnail_path):
                 print 'thumbnail not found for {0}'.format(episode_id)
                 continue
-            thumbnail_color = get_dominant_color(thumbnail_path)
-            connection.execute(sa.text(
-                "UPDATE episodes SET thumbnail_color = '{0}' WHERE id = '{1}'".format(thumbnail_color, episode_id)))
+            try:
+                thumbnail_color = get_dominant_color(thumbnail_path, quality=5)
+                connection.execute(sa.text(
+                    "UPDATE episodes SET thumbnail_color = '{0}' WHERE id = '{1}'".format(thumbnail_color, episode_id)))
+            except Exception as error:
+                print error
 
         print 'Finish for bangumi #{0}'.format(bangumi_id)
 

--- a/utils/color.py
+++ b/utils/color.py
@@ -1,7 +1,7 @@
 from colorthief import ColorThief
 
 
-def get_dominant_color(path):
+def get_dominant_color(path, quality=1):
     color_thief = ColorThief(path)
-    (r, g, b) = color_thief.get_color(quality=1)
+    (r, g, b) = color_thief.get_color(quality=quality)
     return '#{0:02x}{1:02x}{2:02x}'.format(r, g, b)


### PR DESCRIPTION
The previous PR has bug in alembic upgrade scripts.
When colorthief raise an error, the progress interrupt and cannot continue.

This PR modifies alembic upgrade script to ignore that error and continue to process images.
For those who have already used the upgrade script, use `python ./tools.py --cover` to process images individually.