### PR TITLE
synchronize API will always return success even the operation failed

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -162,8 +162,11 @@ Add/update the watch history and progress. When this operation is success the fa
 ### Synchronize Episode History [POST /api/watch/history/synchronize]
 
 Batch synchronize episode history to server. By comparing with last_watch_time between client and server.
-a watch_progress record may be updated or untouched. if last_watch_time from client is later or equal than server, 
+a watch_progress record may be updated or untouched. if last_watch_time from client is later or equal than server,
 server watch_progress record will be updated, otherwise the record from client will be dropped.
+
+**This API always return success even the operation actually failed.**
+
 Note that the last_watch_time must be UTC time.
 
 + Request  (application/json)

--- a/service/watch.py
+++ b/service/watch.py
@@ -9,6 +9,7 @@ from domain.Bangumi import Bangumi
 from domain.Episode import Episode
 from service.common import utils
 
+import traceback
 import logging
 
 logger = logging.getLogger(__name__)
@@ -159,6 +160,10 @@ class WatchService:
                                                    percentage=record['percentage'])
                     session.add(watch_progress)
             session.commit()
+            return json_resp({'message': 'ok', 'status': 0})
+        except Exception as error:
+            logger.warn(traceback.format_exc(error))
+            # always return success even operation failed
             return json_resp({'message': 'ok', 'status': 0})
         finally:
             SessionManager.Session.remove()


### PR DESCRIPTION
This update aims to solve an rare issue:
When a bangumi is deleted on server side but it has watch records remains in client. an synchronize API invoke will raise an exception because insert a new record violates the foreign key restriction on watch_progress table. If the API returns failure, the error record will always exists and continues to make unsuccessful API call.
With always return success feature, the error record will be purged and future API call will succeed