### PR TITLE
2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.6.2
+
+Change bangumi.moe scanner, now will emit torrent url for matched items instead magnet uri. 
+
 # 2.6.1
 
 Add type parameter in admin/list-bangumi api and home/list-bangumi API

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ further more, the information can be used for more user friendly function.
 
 ## Installation
 
-requirements: python 2.7, deluge ( > 1.3.12 ), postgresql 9.3 and above, ffmpeg, nodejs, python-imaging
+requirements: python 2.7, deluge ( >= 1.3.13 ), postgresql 9.3 and above, ffmpeg, nodejs, python-imaging
 
 ### dependencies:
 


### PR DESCRIPTION
Change bangumi.moe scanner, now will emit torrent url for matched items instead magnet uri.
Note: if you are using deluge <= 1.3.13, you must update your deluge before update this.