### PR TITLE
2.6.4

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -477,7 +477,9 @@ Add a bangumi
 ### Update Bangumi [PUT /api/admin/bangumi/{bangumi_id}]
 
 Update a bangumi, this operation will not update all fields which client post. To learn which field is allowed to update,
-see the source code
+see the source code.
+
+Special Notice: when you try to update maintained_by, you should give a `user` object. if you want to reset to System, you should give a null value.
 
 + Parameters
     + `bangumi_id` (string, required)

--- a/service/admin.py
+++ b/service/admin.py
@@ -319,11 +319,13 @@ class AdminService:
             if not bangumi.eps_no_offset:
                 # in case the eps_no_offset is empty string
                 bangumi.eps_no_offset = None
-            bangumi.maintained_by_uid = bangumi_dict.get('maintained_by_uid')
-            if not bangumi.maintained_by_uid:
+            maintained_by = bangumi_dict.get('maintained_by')
+            if maintained_by is None:
                 bangumi.maintained_by_uid = None
                 # add this try to trace the mysterious bug on maintained_by_uid changing.
                 logger.error('maintained_by_uid is setting to None', exc_info=True)
+            else:
+                bangumi.maintained_by_uid = maintained_by['id']
             bangumi.update_time = datetime.utcnow()
 
             session.commit()


### PR DESCRIPTION
fix bug which may cause the maintained_by_uid reset to null unexpectedly by update bangumi API. This is usually happend when an admin user update the scanner section.