### PR TITLE
Change check favorite api response to fix an issue

### DIFF
--- a/service/watch.py
+++ b/service/watch.py
@@ -267,10 +267,10 @@ class WatchService:
             filter(Favorites.user_id == user_id).\
             first()
         if not favorite:
-            raise ClientError(ClientError.NOT_FOUND, 404, {bangumi_id: bangumi_id})
+            return json_resp({'data': 0, 'status': 0})
         else:
             favorite.check_time = datetime.utcnow()
-            return json_resp({'data': favorite.check_time, 'status': 0})
+            return json_resp({'data': favorite.check_time, 'status': favorite.status})
 
 
 watch_service = WatchService()


### PR DESCRIPTION
check favorite api: change api response to fix issue, details provided below.

Interface should also return normal response when queried bangumi_id is not favorited by user.
To tell whether the queried bangumi is favorited by user, we define the unused return param "status" as the following values:
0 - not favorited by user
1/2/3/4/5 - same as favorite.status in DB.